### PR TITLE
Include expiration date feature in preprocessing

### DIFF
--- a/Tarea2_modelos.ipynb
+++ b/Tarea2_modelos.ipynb
@@ -932,7 +932,7 @@
       "outputs": [],
       "source": [
         "# Variables numéricas y categóricas\n",
-        "numericas = ['peso', 'volumen']\n",
+        "numericas = ['peso', 'volumen', 'fecha_vencimiento']\n",
         "categoricas = ['tipo_certificacion']\n",
         "\n",
         "X = df[numericas + categoricas]\n",


### PR DESCRIPTION
## Summary
- add the fecha_vencimiento field to the list of numeric features in the preprocessing step so it is standardized with the other magnitudes

## Testing
- unable to run notebook execution because pandas and scikit-learn are not available in the execution environment

------
https://chatgpt.com/codex/tasks/task_e_68dae0a891648321a0f41e0fecc330d7